### PR TITLE
Refactor server configuration for HTTPS in development

### DIFF
--- a/server/config/server.config.js
+++ b/server/config/server.config.js
@@ -113,12 +113,12 @@ export default class ServerConfig {
 
       // Create an HTTP/HTTPS server
       const httpServer =
-        process.env.NODE_ENV === 'local_dev'
-          ? http.createServer(this.app)
+        // process.env.NODE_ENV === 'local_dev'
+        //   ? http.createServer(this.app)
+        //   : https.createServer(options, this.app);
+        process.env.NODE_ENV === 'development'
+          ? http.createServer(options, this.app)
           : https.createServer(options, this.app);
-      process.env.NODE_ENV === 'development'
-        ? http.createServer(options, this.app)
-        : https.createServer(options, this.app);
 
       httpServer.listen(this.port, () => {
         this.console.info(`🚀..Server running on port: ${this.port}`);


### PR DESCRIPTION
Update the server configuration to use HTTPS in the development environment instead of HTTP.