### PR TITLE
Add error handling for therapy request retrieval in ThrpyReq model

### DIFF
--- a/server/models/thrpyReq.js
+++ b/server/models/thrpyReq.js
@@ -347,9 +347,19 @@ export default class ThrpyReq {
         return { message: 'Error loading session forms', error: -1 };
       }
 
+      const ThrpyReq = await this.getThrpyReqById({
+        thrpy_id: postThrpyReq[0],
+      });
+
+      if (!ThrpyReq) {
+        logger.error('Error getting therapy request');
+        return { message: 'Error getting therapy request', error: -1 };
+      }
+
       // Return a success message
       return {
         message: 'Therapy request, sessions, and reports created successfully',
+        rec: ThrpyReq,
       };
     } catch (error) {
       logger.error(error);


### PR DESCRIPTION
This pull request includes a modification to the `ThrpyReq` class in the `server/models/thrpyReq.js` file to enhance error handling and return additional data when creating therapy requests, sessions, and reports.

Error handling improvements:

* Added a call to `this.getThrpyReqById` to retrieve the therapy request by ID after creating it.
* Included a check to ensure the therapy request exists, logging an error and returning an error message if it does not.

Data return enhancements:

* Modified the return statement to include the retrieved therapy request in the response.