### PR TITLE
Add discharge email template handling and sort session objects in therapy requests

### DIFF
--- a/server/models/session.js
+++ b/server/models/session.js
@@ -161,6 +161,10 @@ export default class Session {
           .where('status_yn', 1)
           .andWhere('req_id', checkDischarge[0].thrpy_req_id);
 
+        const dischargeEmlTmplt = this.emailTmplt.sendDischargeEmail({
+          client_id: checkThrpyReq[0].client_id,
+        });
+
         // console.log(checkThrpyReq);
         // const recUser = await this.userProfile.getUserProfileById({
         //   user_profile_id: checkThrpyReq[0].client_id,

--- a/server/models/thrpyReq.js
+++ b/server/models/thrpyReq.js
@@ -744,6 +744,18 @@ export default class ThrpyReq {
 
       const rec = await query;
 
+      const orderSessionObj = (rec) => {
+        rec.forEach((thrpyReq) => {
+          if (thrpyReq.session_obj) {
+            thrpyReq.session_obj = thrpyReq.session_obj.sort(
+              (a, b) => a.session_id - b.session_id,
+            );
+          }
+        });
+      };
+
+      orderSessionObj(rec);
+
       if (!rec) {
         logger.error('Error getting therapy request');
         return { message: 'Error getting therapy request', error: -1 };


### PR DESCRIPTION
This pull request includes changes to improve the functionality of email templates and the ordering of session objects in therapy requests. The most important changes include adding a method to send discharge emails and a function to sort session objects.

Enhancements to email functionality:

* [`server/models/session.js`](diffhunk://#diff-bb67af2f02247a1d8d2d180db446072d4b2320335a05fa89de094a533e1a123bR164-R167): Added a method to send discharge emails using the `emailTmplt.sendDischargeEmail` function.

Improvements to therapy request handling:

* [`server/models/thrpyReq.js`](diffhunk://#diff-8c96712eadb5e86f93b95b7fb95fecfe18eb36b1fe521d730675f882ce95beadR747-R758): Introduced the `orderSessionObj` function to sort session objects by `session_id` in therapy requests.