### PR TITLE
Implement hard delete for therapy requests and sessions, enhance user Implement hard delete for therapy requests and sessions, enhance user target outcome handling, and update validation schema in user profile service

### DIFF
--- a/server/models/thrpyReq.js
+++ b/server/models/thrpyReq.js
@@ -681,6 +681,40 @@ export default class ThrpyReq {
 
   //////////////////////////////////////////
 
+  //This function is for Hard delete
+  async deleteThrpyReqById(req_id) {
+    try {
+      const deletedSessions = await db
+        .withSchema(`${process.env.MYSQL_DATABASE}`)
+        .from('session')
+        .where('thrpy_req_id', req_id)
+        .del();
+
+      if (!deletedSessions) {
+        logger.error('Error deleting therapy sessions');
+        return { message: 'Error deleting therapy sessions', error: -1 };
+      }
+
+      const delThrpyReq = await db
+        .withSchema(`${process.env.MYSQL_DATABASE}`)
+        .from('thrpy_req')
+        .where('req_id', req_id)
+        .del();
+      if (!delThrpyReq) {
+        logger.error('Error deleting therapy request');
+        return { message: 'Error deleting therapy request', error: -1 };
+      }
+
+      return { message: 'Therapy request and sessions deleted successfully' };
+    } catch (error) {
+      console.error(error);
+      logger.error(error);
+      return { message: 'Error deleting therapy request', error: -1 };
+    }
+  }
+
+  //////////////////////////////////////////
+
   // async putThrpyDischarge(data) {
   //   try {
   //     const putSessions = await db

--- a/server/services/userProfile.js
+++ b/server/services/userProfile.js
@@ -65,6 +65,9 @@ export default class UserProfileService {
       user_typ_id: joi.number().optional(),
       clam_num: joi.number().optional(),
       status_yn: joi.number().optional(),
+      //fields below are for target outcome
+      target_outcome_id: joi.number().optional(),
+      counselor_id: joi.number().optional(),
     });
 
     // Validate the entire data object against the schema


### PR DESCRIPTION
This pull request includes several updates and new features to the `server/models` and `server/services` directories. The most important changes include the addition of methods for handling therapy requests and user target outcomes, as well as updates to validation schemas.

### New Methods for Therapy Requests and User Target Outcomes:

* [`server/models/thrpyReq.js`](diffhunk://#diff-8c96712eadb5e86f93b95b7fb95fecfe18eb36b1fe521d730675f882ce95beadR684-R717): Added a new method `deleteThrpyReqById` for hard deleting therapy requests and their associated sessions.
* [`server/models/userTargetOutcome.js`](diffhunk://#diff-d109e02441c53f91bec7be9ae2219e424d4a021e2bd6013d7e8f7361e528852eR113-R176): Added new methods `getUserTargetOutcomeLatest` and `delAllDisabledUserTargetOutcomeByUserProfileId` for fetching the latest user target outcome and deleting disabled user target outcomes by user profile ID, respectively.

### Updates to User Profile Handling:

* [`server/models/userProfile.js`](diffhunk://#diff-b219d37d89121c3978780890f2d05aafaf7f9241865a3aa79b7b3ec09185e997R226-R259): Enhanced the `UserProfile` class to handle `target_outcome_id` and related operations, including disabling and posting new user target outcomes. [[1]](diffhunk://#diff-b219d37d89121c3978780890f2d05aafaf7f9241865a3aa79b7b3ec09185e997R226-R259) [[2]](diffhunk://#diff-b219d37d89121c3978780890f2d05aafaf7f9241865a3aa79b7b3ec09185e997R270)

### Updates to Therapy Request Service:

* [`server/services/thrpyReq.js`](diffhunk://#diff-5d48dccb6f255f17c19b0422ca4015112bb852682fe9eb04af535403d99e248dL36-R75): Modified the `putThrpyReqById` method to include validation and regeneration of therapy requests if no changes are detected. Also added a new method `deleteThrpyReqByClientId` for deleting therapy requests by client ID. [[1]](diffhunk://#diff-5d48dccb6f255f17c19b0422ca4015112bb852682fe9eb04af535403d99e248dL36-R75) [[2]](diffhunk://#diff-5d48dccb6f255f17c19b0422ca4015112bb852682fe9eb04af535403d99e248dR220-R264)

### Validation Schema Updates:

* [`server/services/thrpyReq.js`](diffhunk://#diff-5d48dccb6f255f17c19b0422ca4015112bb852682fe9eb04af535403d99e248dL19-R24): Updated the validation schema for `session_format_id` to accept both strings and numbers.
* [`server/services/userProfile.js`](diffhunk://#diff-a1e31d5d39a006217f6dc6955727a343496012ed6ccc19f3f5edcd2f5006dccbR68-R70): Added optional fields `target_outcome_id` and `counselor_id` to the validation schema for user profiles.