### PR TITLE
Enhance feedback handling and email template; add client ID to consent form URL and prevent duplicate feedback submissions

### DIFF
--- a/server/models/emailTmplt.js
+++ b/server/models/emailTmplt.js
@@ -167,7 +167,7 @@ export default class EmailTmplt {
       const sendClientConsentForm = consentFormEmail(
         data.email,
         data.client_name,
-        `${process.env.BASE_URL}${process.env.FORMS}consent`,
+        `${process.env.BASE_URL}${process.env.FORMS}consent?client_id=${data.client_id}`,
       );
 
       const sendConsentForm = this.sendEmail.sendMail(sendClientConsentForm);

--- a/server/models/feedback.js
+++ b/server/models/feedback.js
@@ -2,6 +2,7 @@ import DBconn from '../config/db.config.js';
 import knex from 'knex';
 import logger from '../config/winston.js';
 import Session from './session.js';
+import { cli } from 'winston/lib/winston/config/index.js';
 
 const db = knex(DBconn.dbConn.development);
 
@@ -769,9 +770,22 @@ export default class Feedback {
 
   async postCONSENTFeedback(data) {
     try {
+      const checkFeedBackSessionId = await this.getFeedbackById({
+        client_id: data.client_id,
+        form_id: 23,
+      });
+
+      if (checkFeedBackSessionId.length > 0) {
+        return {
+          message: 'Feedback already exists for this session',
+          error: -1,
+        };
+      }
+
       const recFeedback = await this.postFeedback({
         client_id: data.client_id,
         feedback_json: data,
+        form_id: 23,
       });
 
       if (recFeedback.error) {

--- a/server/models/userProfile.js
+++ b/server/models/userProfile.js
@@ -190,6 +190,7 @@ export default class UserProfile {
       const sendClientConsentForm = this.emailTmplt.sendClientConsentEmail({
         email: data.email,
         client_name: `${data.user_first_name} ${data.user_last_name}`,
+        client_id: postUsrProfile[0],
       });
 
       return { message: 'User profile created successfully' };


### PR DESCRIPTION
This pull request includes several changes to the `server/models` directory to enhance the functionality of email templates, feedback handling, and user profile creation. The most important changes are summarized below:

### Enhancements to Email Templates:
* [`server/models/emailTmplt.js`](diffhunk://#diff-f867a80f78decb0f945a5e9973d614903ab9342beb6a04bc601b982f503303e6L170-R170): Updated the consent form URL to include `client_id` as a query parameter when sending client consent forms.

### Improvements in Feedback Handling:
* [`server/models/feedback.js`](diffhunk://#diff-5e2bf188d1fb995c6c81d59dd52e1fdec8c59e69dd61e4e765de115ac91cecaaR773-R788): Added a check to prevent duplicate feedback for the same session by verifying if feedback already exists for the given `client_id` and `form_id`.

### User Profile Creation:
* [`server/models/userProfile.js`](diffhunk://#diff-b219d37d89121c3978780890f2d05aafaf7f9241865a3aa79b7b3ec09185e997R193): Modified the user profile creation process to include `client_id` when sending client consent emails.

### Minor Import Adjustments:
* [`server/models/feedback.js`](diffhunk://#diff-5e2bf188d1fb995c6c81d59dd52e1fdec8c59e69dd61e4e765de115ac91cecaaR5): Added an import statement for `cli` from `winston/lib/winston/config/index.js`.