### PR TITLE
Remove authentication middleware from feedback routes for streamlined access

### DIFF
--- a/server/routes/feedback.js
+++ b/server/routes/feedback.js
@@ -6,51 +6,51 @@ import { authenticate } from '../middlewares/token.js';
 const router = Router();
 const feedbackController = new FeedbackController();
 
-router.post('/', authenticate, AsyncWrapper(feedbackController.postFeedback));
+router.post('/', AsyncWrapper(feedbackController.postFeedback));
 
-router.put('/', authenticate, AsyncWrapper(feedbackController.putFeedbackById));
+router.put('/', AsyncWrapper(feedbackController.putFeedbackById));
 
-router.get('/', authenticate, AsyncWrapper(feedbackController.getFeedbackById));
+router.get('/', AsyncWrapper(feedbackController.getFeedbackById));
 
 router.post(
   '/gad7',
-  authenticate,
+
   AsyncWrapper(feedbackController.postGAD7Feedback),
 );
 
 router.post(
   '/phq9',
-  authenticate,
+
   AsyncWrapper(feedbackController.postPHQ9Feedback),
 );
 
 router.post(
   '/pcl5',
-  authenticate,
+
   AsyncWrapper(feedbackController.postPCL5Feedback),
 );
 
 router.post(
   '/whodas',
-  authenticate,
+
   AsyncWrapper(feedbackController.postWHODASFeedback),
 );
 
 router.post(
   '/ipf',
-  authenticate,
+
   AsyncWrapper(feedbackController.postIPFSFeedback),
 );
 
 router.post(
   '/smart-goal',
-  authenticate,
+
   AsyncWrapper(feedbackController.postSMARTGOALFeedback),
 );
 
 router.post(
   '/consent',
-  authenticate,
+
   AsyncWrapper(feedbackController.postCONSENTFeedback),
 );
 


### PR DESCRIPTION
This pull request includes changes to the `server/routes/feedback.js` file. The primary change is the removal of the `authenticate` middleware from various routes. This simplifies the code by removing the authentication step from each route handler.

Key changes:

* [`server/routes/feedback.js`](diffhunk://#diff-a04acc3543ad5ce5649b30410f90ab4df7fb0f474f28e242b0f05c9b51871f74L9-R53): Removed the `authenticate` middleware from all routes handling feedback operations, including `postFeedback`, `putFeedbackById`, `getFeedbackById`, and various other specific feedback types.