### PR TITLE
Merge client lists from enrollments and therapy requests, removing duplicates

### DIFF
--- a/server/models/userProfile.js
+++ b/server/models/userProfile.js
@@ -356,11 +356,22 @@ export default class UserProfile {
       }
 
       if (data.counselor_id && data.role_id == 2) {
-        const clientList = await db
+        const clientListFromEnrollment = await db
+          .withSchema(`${process.env.MYSQL_DATABASE}`)
+          .distinct('client_id')
+          .from('client_enrollments')
+          .where('user_id', data.counselor_id);
+
+        const clientListFromThrpyReq = await db
           .withSchema(`${process.env.MYSQL_DATABASE}`)
           .distinct('client_id')
           .from('thrpy_req')
           .where('counselor_id', data.counselor_id);
+
+        // Merge the two arrays and remove duplicate elements
+        const clientList = [
+          ...new Map([...clientListFromEnrollment, ...clientListFromThrpyReq].map(client => [client.client_id, client])).values()
+        ];
 
         const clientIds = clientList.map((client) => client.client_id);
 


### PR DESCRIPTION
This pull request includes changes to the `UserProfile` class in `server/models/userProfile.js` to improve the handling of client lists for counselors. The most important changes include querying client IDs from multiple tables and merging the results to remove duplicates.

Improvements to client list handling:

* [`server/models/userProfile.js`](diffhunk://#diff-b219d37d89121c3978780890f2d05aafaf7f9241865a3aa79b7b3ec09185e997L359-R375): Added a query to retrieve client IDs from the `client_enrollments` table and merged the results with those from the `thrpy_req` table, removing duplicates to ensure a comprehensive and unique list of client IDs.